### PR TITLE
use go 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19 AS build
+FROM golang:1.20 AS build
 COPY . /build
 WORKDIR /build
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-extldflags '-static' -s -w" -o brickd_exporter


### PR DESCRIPTION
ith go1.19 you get the following error - using 1.20 fixes it

```
0.636 go: downloading github.com/prometheus/client_golang v1.19.0                                                                                        
0.637 go: downloading github.com/Tinkerforge/go-api-bindings v0.0.0-20240227173217-368b7493d93e                                                          
0.637 go: downloading gopkg.in/yaml.v2 v2.4.0                                                                                                            
0.637 go: downloading github.com/sirupsen/logrus v1.9.3                                                                                                  
0.637 go: downloading github.com/spf13/pflag v1.0.5
1.020 go: downloading github.com/eclipse/paho.mqtt.golang v1.4.3
1.172 go: downloading golang.org/x/sys v0.19.0
1.175 go: downloading github.com/prometheus/client_model v0.6.1
1.211 go: downloading github.com/prometheus/common v0.53.0
1.211 go: downloading github.com/beorn7/perks v1.0.1
1.211 go: downloading github.com/cespare/xxhash/v2 v2.3.0
1.211 go: downloading github.com/prometheus/procfs v0.14.0
1.211 go: downloading google.golang.org/protobuf v1.33.0
1.220 go: downloading github.com/gorilla/websocket v1.5.1
1.221 go: downloading golang.org/x/net v0.24.0
1.221 go: downloading golang.org/x/sync v0.7.0
11.44 # github.com/prometheus/common/model
11.44 /go/pkg/mod/github.com/prometheus/common@v0.53.0/model/metric.go:364:33: undefined: strings.CutPrefix
11.44 note: module requires Go 1.20
------
Dockerfile:4
--------------------
   2 |     COPY . /build
   3 |     WORKDIR /build
   4 | >>> RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-extldflags '-static' -s -w" -o brickd_exporter
   5 |     
   6 |     FROM busybox
--------------------
ERROR: failed to solve: process "/bin/sh -c CGO_ENABLED=0 GOOS=linux go build -a -ldflags \"-extldflags '-static' -s -w\" -o brickd_exporter" did not complete successfully: exit code: 1
```